### PR TITLE
Collection ordering

### DIFF
--- a/Collection.py
+++ b/Collection.py
@@ -44,7 +44,16 @@ class Collection(pd.DataFrame):
     def sort_by(self, column, ascending=True):
         """Sorts the Collection in place by the (single) specified card
         property."""
-        self.sort_values([column], ascending=ascending, inplace=True)
+        # define key functions for columns with special sorting rules
+        def rarity_key(column):
+            codes = {"C":0, "U":1, "R":2, "M":3}; return column.map(codes)
+        # the default key function is no transformation
+        key = lambda x: x
+        # set keys for columns with special sorting rules
+        if column=="Rarity": key=rarity_key
+        # finally, perform the sorting:
+        self.sort_values([column], ascending=ascending, inplace=True, key=key)
+        self.reset_index(drop=True, inplace=True)
         
     # Save/load functionality =================================================
     def save(self, fpath=None):
@@ -88,6 +97,16 @@ class Collection(pd.DataFrame):
 if __name__ == "__main__":
     
     test = Collection.from_file("Library/SampleCollection.csv")
+    
+#    s = test["Rarity"]
+#    
+#    def rar(r):
+#        codes = {"C":0, "U":1, "R":2, "M":3}
+#        return r.map(codes)
+#        
+#    test.sort_values(["Rarity"], key=rar, ascending=False)
+        
+    
 #    test.iloc[3:7,0]=True
 #    test2 = test.copy_selected()
 #    test.drop_selected()

--- a/Collection.py
+++ b/Collection.py
@@ -47,15 +47,15 @@ class Collection(pd.DataFrame):
     def sort_by(self, column, ascending=True):
         """Sorts the Collection in place by the (single) specified card
         property."""
-        # define key functions for columns with special sorting rules
-        def rarity_key(column):
-            codes = {"C":0, "U":1, "R":2, "M":3}; return column.map(codes)
-        # the default key function is no transformation
-        key = lambda x: x
-        # set keys for columns with special sorting rules
-        if column=="Rarity": key=rarity_key
-        # finally, perform the sorting:
-        self.sort_values([column], ascending=ascending, inplace=True, key=key)
+        if column == "Set": # Sorting by set = sorting by release date
+            self.sort_values(["Released"], ascending=ascending, inplace=True)
+        if column == "Rarity": # Sorting by rarity requires a key
+            def rarity_key(column):
+                codes = {"C":0, "U":1, "R":2, "M":3}; return column.map(codes)
+            self.sort_values([column], ascending=ascending, inplace=True,
+                             key=rarity_key)
+        else: # Default to normal sorting for undefined columns
+            self.sort_values([column], ascending=ascending, inplace=True)
         self.reset_index(drop=True, inplace=True)
         
     # Save/load functionality =================================================

--- a/Collection.py
+++ b/Collection.py
@@ -41,6 +41,10 @@ class Collection(pd.DataFrame):
         """Adds the cards from another Collection to this one."""
         combined = pd.concat([self, collection], axis=0).reset_index()
         self.__init__(combined, fpath=self.fpath)
+    def sort_by(self, column, ascending=True):
+        """Sorts the Collection in place by the (single) specified card
+        property."""
+        self.sort_values([column], ascending=ascending, inplace=True)
         
     # Save/load functionality =================================================
     def save(self, fpath=None):
@@ -84,8 +88,8 @@ class Collection(pd.DataFrame):
 if __name__ == "__main__":
     
     test = Collection.from_file("Library/SampleCollection.csv")
-    test.iloc[3:7,0]=True
-    test2 = test.copy_selected()
-    test.drop_selected()
-    test3 = Collection.from_search("t:ouphe")
-    test3.save(fpath="Library/Ouphe.csv")
+#    test.iloc[3:7,0]=True
+#    test2 = test.copy_selected()
+#    test.drop_selected()
+#    test3 = Collection.from_search("t:ouphe")
+#    test3.save(fpath="Library/Ouphe.csv")

--- a/Collection.py
+++ b/Collection.py
@@ -47,27 +47,27 @@ class Collection(pd.DataFrame):
     def sort_by(self, column, ascending=True):
         """Sorts the Collection in place by the (single) specified card
         property."""
-        elif column == "Set": # Sorting by set = sorting by release date
-            self.sort_values(["Released"], ascending=ascending, inplace=True)
-        elif column == "Rarity": # Sorting by rarity requires a key
-            def rarity_key(column):
-                codes = {"C":0, "U":1, "R":2, "M":3}; return column.map(codes)
-            self.sort_values([column], ascending=ascending, inplace=True,
-                             key=rarity_key)
-        elif column == "Color": # Sorting by color requires a key
-            def color_key(column):
-                color_modifier = {'':0, 'W':0.01, 'U':0.02, 'B':0.03, 'R':0.04,
+        def sort_key(column):
+            rarity_codes = {"C":0, "U":1, "R":2, "M":3}
+            color_codes = {'':0, 'W':0.01, 'U':0.02, 'B':0.03, 'R':0.04,
                     'G':0.05, 'WU':0.10, 'WB':0.11, 'UB':0.12, 'UR':0.13,
                     'BR':0.14, 'BG':0.15, 'RG':0.16, 'WR':0.17, 'WG':0.18,
                     'UG':0.19, 'WUB':0.20, 'WUR':0.21, 'UBR':0.22, 'UBG':0.23,
                     'BRG':0.24, 'WBR':0.25, 'WRG':0.26, 'URG':0.27, 'WUG':0.28,
                     'WBG':0.29, 'WUBR':0.30, 'UBRG':0.31, 'WBRG':0.32,
                     'WURG':0.33, 'WUBG':0.34, 'WUBRG':0.40}
-                return column.map(color_modifier)
-            self.sort_values([column], ascending=ascending, inplace=True,
-                             key=color_key)
-        else: # Default to normal sorting for undefined columns
-            self.sort_values([column], ascending=ascending, inplace=True)
+            # Sorting by set = sorting by release date
+            if column.name == "Set": return self["Released"]
+            # Sorting by color/rarity requires a keying to a numeric value
+            elif column.name == "Rarity": return column.map(rarity_codes)
+            elif column.name == "Color": return column.map(color_codes)
+            # Sorting by cost is a combination of MV/Color
+            elif column.name == "Cost":
+                return self["MV"] + self["Color"].map(color_codes)
+            # Default to normal sorting for undefined columns
+            else: return column
+        self.sort_values([column], ascending=ascending, inplace=True,
+                         key=sort_key)
         self.reset_index(drop=True, inplace=True)
         
     # Save/load functionality =================================================
@@ -112,3 +112,4 @@ class Collection(pd.DataFrame):
 if __name__ == "__main__":
     
     test = Collection.from_file("Library/SampleCollection.csv")
+    test2 = Collection.from_search("e:ala")

--- a/Collection.py
+++ b/Collection.py
@@ -18,7 +18,8 @@ class Collection(pd.DataFrame):
     that may represent a deck, the contents of a binder or box, etc."""
     def __init__(self, *args, fpath=None, **kwargs):
         # Fix columns to the currently in-use card properties
-        kwargs['columns'] = ['Sel', 'Name', 'Cost', 'Set', 'Rarity']
+        kwargs['columns'] = ['Sel', 'Name', 'Cost', 'Set', 'Rarity', 'MV',
+            'Color', 'Released']
         super().__init__(*args, **kwargs)
         self.fpath = fpath
         # Needs a name member for certain operations, based on the file path,
@@ -28,6 +29,8 @@ class Collection(pd.DataFrame):
         else: self.name = "Unnamed"
         # set column indicating selection status to False
         self.Sel = False
+        # set any blank values to an empty string
+        self.fillna("", inplace=True)
         
     # Editing Functionality ===================================================
     def copy_selected(self):
@@ -97,18 +100,3 @@ class Collection(pd.DataFrame):
 if __name__ == "__main__":
     
     test = Collection.from_file("Library/SampleCollection.csv")
-    
-#    s = test["Rarity"]
-#    
-#    def rar(r):
-#        codes = {"C":0, "U":1, "R":2, "M":3}
-#        return r.map(codes)
-#        
-#    test.sort_values(["Rarity"], key=rar, ascending=False)
-        
-    
-#    test.iloc[3:7,0]=True
-#    test2 = test.copy_selected()
-#    test.drop_selected()
-#    test3 = Collection.from_search("t:ouphe")
-#    test3.save(fpath="Library/Ouphe.csv")

--- a/Collection.py
+++ b/Collection.py
@@ -47,13 +47,25 @@ class Collection(pd.DataFrame):
     def sort_by(self, column, ascending=True):
         """Sorts the Collection in place by the (single) specified card
         property."""
-        if column == "Set": # Sorting by set = sorting by release date
+        elif column == "Set": # Sorting by set = sorting by release date
             self.sort_values(["Released"], ascending=ascending, inplace=True)
-        if column == "Rarity": # Sorting by rarity requires a key
+        elif column == "Rarity": # Sorting by rarity requires a key
             def rarity_key(column):
                 codes = {"C":0, "U":1, "R":2, "M":3}; return column.map(codes)
             self.sort_values([column], ascending=ascending, inplace=True,
                              key=rarity_key)
+        elif column == "Color": # Sorting by color requires a key
+            def color_key(column):
+                color_modifier = {'':0, 'W':0.01, 'U':0.02, 'B':0.03, 'R':0.04,
+                    'G':0.05, 'WU':0.10, 'WB':0.11, 'UB':0.12, 'UR':0.13,
+                    'BR':0.14, 'BG':0.15, 'RG':0.16, 'WR':0.17, 'WG':0.18,
+                    'UG':0.19, 'WUB':0.20, 'WUR':0.21, 'UBR':0.22, 'UBG':0.23,
+                    'BRG':0.24, 'WBR':0.25, 'WRG':0.26, 'URG':0.27, 'WUG':0.28,
+                    'WBG':0.29, 'WUBR':0.30, 'UBRG':0.31, 'WBRG':0.32,
+                    'WURG':0.33, 'WUBG':0.34, 'WUBRG':0.40}
+                return column.map(color_modifier)
+            self.sort_values([column], ascending=ascending, inplace=True,
+                             key=color_key)
         else: # Default to normal sorting for undefined columns
             self.sort_values([column], ascending=ascending, inplace=True)
         self.reset_index(drop=True, inplace=True)

--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -1,12 +1,12 @@
-Name;Cost;Set;Rarity
-Duress;{B};STA;U
-Duress;{B};M21;C
-Mindslicer;{2}{B}{B};9ED;R
-Needle Storm;{2}{G};TMP;U
-Rule of Law;{2}{W};MRD;R
-Time Warp;{3}{U}{U};M10;M
-Arcum's Astrolabe;{S};MH1;C
-Runes of the Deus;{4}{R/G};SHM;C
-Kozilek, the Great Distortion;{8}{C}{C};OGW;M
-Gitaxian Probe;{U/P};NPH;C
-Beseech the Queen;{2/B}{2/B}{2/B};HOP;U
+Name;Cost;Set;Rarity;MV;Color;Released
+Duress;{B};MID;C;1;B;2021-09-24
+Duress;{B};MID;C;1;B;2021-09-24
+Mindslicer;{2}{B}{B};9ED;R;4;B;2005-07-29
+Needle Storm;{2}{G};TPR;U;3;G;2015-05-06
+Rule of Law;{2}{W};M20;U;3;W;2019-07-12
+Time Warp;{3}{U}{U};TPR;M;5;U;2015-05-06
+Arcum's Astrolabe;{S};MH1;C;1;;2019-06-14
+Runes of the Deus;{4}{R/G};SHM;C;5;RG;2008-05-02
+Kozilek, the Great Distortion;{8}{C}{C};OGW;M;10;;2016-01-22
+Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
+Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04

--- a/MainGUI.py
+++ b/MainGUI.py
@@ -68,6 +68,13 @@ class CollectionModel(QtCore.QAbstractTableModel):
             return True
         return False
             
+    # Other re-implemented functions ==========================================
+    def sort(self, column, order):
+        ascending = True if order==QtCore.Qt.AscendingOrder else False
+        column_name = self.collection.columns[column]
+        self.collection.sort_by(column_name, ascending=ascending)  
+        self.layoutChanged.emit()        
+            
     # Nonstandard functions ===================================================
     def parseManaCost(self, index, symbol_size=15):
         """Retrieves the mana cost from the card at (index) and returns a
@@ -110,6 +117,8 @@ class CollectionView(QtWidgets.QTableView):
                 self.setColumnWidth(c, self.columnWidths[columns[c]])
         # Connect the on-click functionality
         self.clicked.connect(self.onClick)
+        # Set the columns to sort on click
+        self.setSortingEnabled(True)
     def onClick(self):
         """Defines what happens when the table is clicked."""
         index = self.selectionModel().currentIndex()

--- a/MainGUI.py
+++ b/MainGUI.py
@@ -93,7 +93,8 @@ class CollectionModel(QtCore.QAbstractTableModel):
 class CollectionView(QtWidgets.QTableView):
     """The view object for GUI interface with a model/collection."""
     # Class variable that dictates the appropriate width of columns
-    columnWidths = {"Sel":22, "Name":200, "Cost":60, "Set":50, "Rarity":50}
+    columnWidths = {"Sel":22, "Name":200, "Cost":60, "Set":50, "Rarity":50,
+                    "MV":50, "Color":50, "Released":100}
     def __init__(self, collection, *args, fname=None, **kwargs):
         super().__init__(*args, **kwargs)
         # create and set the collection model.

--- a/Search.py
+++ b/Search.py
@@ -22,7 +22,8 @@ class ScryfallPortal:
         data = pd.DataFrame.from_dict(data)
         # Retrieve and rename the columns expected by the collection object.
         scrynames = {'name':'Name', 'mana_cost':'Cost', 'set':'Set',
-            'rarity':'Rarity'}
+            'rarity':'Rarity', 'cmc':'MV', 'colors':'Color',
+            'released_at':'Released'}
         data = data[list(scrynames.keys())]
         data.rename(columns=scrynames, inplace=True)
         # Rarity column needs to be remapped to one-letter codes
@@ -30,6 +31,14 @@ class ScryfallPortal:
         data.replace({'Rarity':rarities}, inplace=True)
         # Set abbreviations should be capatalized
         data['Set'] = data['Set'].apply(str.upper)
+        # Mana value should be an integer
+        data['MV'] = data['MV'].apply(int)
+        # Colors should be sorted and joined into a string
+        color_order = {'W':0, 'U':1, 'B':2, 'R':3, 'G':4}
+        def sort_join_colors(colors):
+            colors.sort(key=(lambda c: color_order[c]))
+            return "".join(colors)
+        data["Color"] = data['Color'].apply(sort_join_colors)
         return data
     def request(self, uri, **kwargs):
         """Makes a request from Scryfall's API at the specified uri, and
@@ -63,5 +72,5 @@ class ScryfallPortal:
         
 if __name__ == '__main__':
     
-    portal = Scryfall()
+    portal = ScryfallPortal()
     test = portal.search('!"Intet, the Dreamer" unique:prints')


### PR DESCRIPTION
Incorporated sorting for Collection objects, both from the command line and in the GUI. Custom sorting was implemented enables cards to be properly ordered by their features, including Set, Mana Cost and Rarity.

**Notes**
 - Ordering by Mana Cost requires knowledge of the Color and Mana Value, and while MV could be easy to deduce from Mana Cost, Color is not in all cases (due to the existence of colored 0-cost cards). Meanwhile, ordering by set should order by release date, so that must be known as well. This simplest implementation solves both these by introducing 3 new card features (pulled from the web) for Collections to track: Color, MV and Released (release date).
 - As more card features are added in the future, they may require new custom sorting mechanisms to be implemented, although most planned card features (e.g. price, quantity) can be sorted by default (i.e. numerically or alphabetically) requiring no further tinkering.