### PR TITLE
Bugfix: multiple mana costs

### DIFF
--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -4,6 +4,7 @@ Arcum's Astrolabe;{S};MH1;C;1;;2019-06-14
 Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
 Duress;{B};MID;C;1;B;2021-09-24
 Duress;{B};MID;C;1;B;2021-09-24
+Fae of Wishes // Granted;{1}{U} // {3}{U};ELD;R;2;U;2019-10-04
 Rule of Law;{2}{W};M20;U;3;W;2019-07-12
 Needle Storm;{2}{G};TPR;U;3;G;2015-05-06
 Mindslicer;{2}{B}{B};9ED;R;4;B;2005-07-29

--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -12,3 +12,4 @@ Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
 Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04
 Horde of Notions;{W}{U}{B}{R}{G};MM2;R;5;WUBRG;2015-05-22
 Fire // Ice;{1}{R} // {1}{U};MH2;R;4;UR;2021-06-18
+Lotus Bloom;;TSR;R;0;;2021-03-19

--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -1,17 +1,17 @@
 Name;Cost;Set;Rarity;MV;Color;Released
-Duress;{B};MID;C;1;B;2021-09-24
-Duress;{B};MID;C;1;B;2021-09-24
-Mindslicer;{2}{B}{B};9ED;R;4;B;2005-07-29
-Needle Storm;{2}{G};TPR;U;3;G;2015-05-06
-Rule of Law;{2}{W};M20;U;3;W;2019-07-12
-Time Warp;{3}{U}{U};TPR;M;5;U;2015-05-06
-Arcum's Astrolabe;{S};MH1;C;1;;2019-06-14
-Runes of the Deus;{4}{R/G};SHM;C;5;RG;2008-05-02
-Kozilek, the Great Distortion;{8}{C}{C};OGW;M;10;;2016-01-22
-Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
-Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04
-Horde of Notions;{W}{U}{B}{R}{G};MM2;R;5;WUBRG;2015-05-22
-Fire // Ice;{1}{R} // {1}{U};MH2;R;4;UR;2021-06-18
 Lotus Bloom;;TSR;R;0;;2021-03-19
+Arcum's Astrolabe;{S};MH1;C;1;;2019-06-14
+Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
+Duress;{B};MID;C;1;B;2021-09-24
+Duress;{B};MID;C;1;B;2021-09-24
+Rule of Law;{2}{W};M20;U;3;W;2019-07-12
+Needle Storm;{2}{G};TPR;U;3;G;2015-05-06
+Mindslicer;{2}{B}{B};9ED;R;4;B;2005-07-29
+Fire // Ice;{1}{R} // {1}{U};MH2;R;4;UR;2021-06-18
+Huntmaster of the Fells // Ravager of the Fells;{2}{R}{G};DKA;M;4;RG;2012-02-03
+Time Warp;{3}{U}{U};TPR;M;5;U;2015-05-06
+Runes of the Deus;{4}{R/G};SHM;C;5;RG;2008-05-02
+Horde of Notions;{W}{U}{B}{R}{G};MM2;R;5;WUBRG;2015-05-22
+Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04
 Jadzi, Oracle of Arcavios // Journey to the Oracle;{6}{U}{U} // {2}{G}{G};STX;M;8;U;2021-04-23
-Huntmaster of the Fells // Ravager of the Fells;{2}{R}{G} // ;DKA;M;4;RG;2012-02-03
+Kozilek, the Great Distortion;{8}{C}{C};OGW;M;10;;2016-01-22

--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -13,3 +13,5 @@ Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04
 Horde of Notions;{W}{U}{B}{R}{G};MM2;R;5;WUBRG;2015-05-22
 Fire // Ice;{1}{R} // {1}{U};MH2;R;4;UR;2021-06-18
 Lotus Bloom;;TSR;R;0;;2021-03-19
+Jadzi, Oracle of Arcavios // Journey to the Oracle;{6}{U}{U} // {2}{G}{G};STX;M;8;U;2021-04-23
+Huntmaster of the Fells // Ravager of the Fells;{2}{R}{G} // ;DKA;M;4;RG;2012-02-03

--- a/Library/SampleCollection.csv
+++ b/Library/SampleCollection.csv
@@ -11,3 +11,4 @@ Kozilek, the Great Distortion;{8}{C}{C};OGW;M;10;;2016-01-22
 Gitaxian Probe;{U/P};NPH;C;1;U;2011-05-13
 Beseech the Queen;{2/B}{2/B}{2/B};HOP;U;6;B;2009-09-04
 Horde of Notions;{W}{U}{B}{R}{G};MM2;R;5;WUBRG;2015-05-22
+Fire // Ice;{1}{R} // {1}{U};MH2;R;4;UR;2021-06-18

--- a/MainGUI.py
+++ b/MainGUI.py
@@ -86,6 +86,7 @@ class CollectionModel(QtCore.QAbstractTableModel):
         QImage of the cost to display."""
         # Retriving and parsing the mana cost string into a list of filenames
         cost_string = self.collection.iloc[index.row(), self.manacolumn]
+        cost_string = cost_string.replace(' // ','{slash}')
         cost_string = cost_string.replace('/','') # for hybrid/phyrex. mana
         symbols = cost_string[1:-1].split('}{')
         # Generate the cost image and painter object
@@ -93,11 +94,16 @@ class CollectionModel(QtCore.QAbstractTableModel):
         image = QtGui.QImage(symbol_size*len(symbols), symbol_size, imgformat)
         image.fill(0) # Fills in a white background
         painter = QtGui.QPainter(image); loc=0
+        # Retrieve and set the font (for inserting slashes)
+        f = painter.font(); f.setPixelSize(symbol_size); painter.setFont(f)
         # render symbols from their individual files and add them to the image
         for sym in symbols:
-            renderer = QtSvg.QSvgRenderer(f'images/mana-symbols/{sym}.svg')
             area = QtCore.QRectF(loc, 0, symbol_size, symbol_size)
-            renderer.render(painter, area)
+            if sym == 'slash':
+                painter.drawText(area, QtCore.Qt.AlignCenter, '//')
+            else:
+                renderer = QtSvg.QSvgRenderer(f'images/mana-symbols/{sym}.svg')
+                renderer.render(painter, area)
             loc += symbol_size
         return image
         

--- a/MainGUI.py
+++ b/MainGUI.py
@@ -101,6 +101,8 @@ class CollectionModel(QtCore.QAbstractTableModel):
             area = QtCore.QRectF(loc, 0, symbol_size, symbol_size)
             if sym == 'slash':
                 painter.drawText(area, QtCore.Qt.AlignCenter, '//')
+            elif sym == '':
+                continue
             else:
                 renderer = QtSvg.QSvgRenderer(f'images/mana-symbols/{sym}.svg')
                 renderer.render(painter, area)

--- a/Search.py
+++ b/Search.py
@@ -71,6 +71,8 @@ class ScryfallPortal:
         ensure that the amount of data pulled does not overload memory."""
         # Pull the first page of search results from the scryfall API:
         js = self.request(self.searchpath, params={'q':query})
+        # escape if the search results are empty, otherwise pull data
+        if 'data' not in js.keys(): return []
         data = js['data']; ncards = len(data)
         # Pull from the next pages in the list while there are more pages AND
         # the maximum number of cards has not been reached:
@@ -88,6 +90,7 @@ class ScryfallPortal:
 if __name__ == '__main__':
     
     portal = ScryfallPortal()
+    test=portal.search("jkjkjk")
 #    test = portal.search('!"Intet, the Dreamer" unique:prints')
-    test = portal.search('jadzi')
+#    test = portal.search('jadzi')
     # Note: Cost and name displays as both sides. Color and MV are front face only.

--- a/Search.py
+++ b/Search.py
@@ -23,12 +23,17 @@ class ScryfallPortal:
         # Unpack neccessary charactoristics for double-faced cards
         if 'card_faces' in data.columns:
             subset = data[data.card_faces.isnull()==False]
-            faces = pd.DataFrame(subset.card_faces.to_list(), index=subset.index)
+            faces = pd.DataFrame(subset.card_faces.to_list(),
+                index=subset.index)
             front = pd.json_normalize(faces.loc[:,0]).set_index(faces.index)
             back = pd.json_normalize(faces.loc[:,1]).set_index(faces.index)
-            # Mana cost (and name) are given for both faces
-            subset.loc[:,'mana_cost'] = (front.loc[:,'mana_cost'] + ' // ' + 
-                back.loc[:,'mana_cost'])
+            # Mana cost (and name) are given for both faces is both have a
+            # mana cost, otherwise for the front face only
+            subset.loc[back['mana_cost']=='','mana_cost'] = \
+                front.loc[back['mana_cost']=='','mana_cost']
+            subset.loc[back['mana_cost']!='','mana_cost'] = \
+                (front.loc[back['mana_cost']!='','mana_cost'] + ' // ' + 
+                back.loc[back['mana_cost']!='','mana_cost'])
             # Color (and mana volue) are for the front face only
             subset.loc[:,'colors'] = front.loc[:,'colors']
             # These columns need to exist in 'data' if they don't already
@@ -90,7 +95,6 @@ class ScryfallPortal:
 if __name__ == '__main__':
     
     portal = ScryfallPortal()
-    test=portal.search("jkjkjk")
 #    test = portal.search('!"Intet, the Dreamer" unique:prints')
-#    test = portal.search('jadzi')
-    # Note: Cost and name displays as both sides. Color and MV are front face only.
+    test = portal.search('jadzi')
+    test2 = portal.search('huntmaster')


### PR DESCRIPTION
This update fixes how cards with multiple mana costs (e.g. MDF, split and adventure cards) as well as cards with no mana cost (e.g. lands) are displayed. (Previously attempting to display these crashed the program.)

**Notes:**
- All cards with multiple names have both names displayed separated by "//". Split, MDF and adventure cards also have both their mana costs displayed separated by "//" (even when one or both of them are 'none').
- Aside from name and mana cost, all other displayed characteristics (e.g. color, MV) for double-faced cards are for their front face only, in keeping with the rules of the game. (Split cards have the combined colors and mana cost of both halves, and adventures have only the characteristics of their 'normal' mode, also in line with the rules.)
- This update also stops the program from crashing when it attempts to retrieve an empty collection from search.